### PR TITLE
Partner trainerproc fixes

### DIFF
--- a/migration_scripts/convert_partner_parties.py
+++ b/migration_scripts/convert_partner_parties.py
@@ -187,7 +187,6 @@ trainer_pic_definition             = re.compile(r'\.trainerPic = TRAINER_BACK_PI
 trainer_name_definition            = re.compile(r'\.trainerName = _\("([^"]*)"\)')
 trainer_items_definition           = re.compile(r'\.items = \{([^}]*)\}')
 trainer_item_definition            = re.compile(r'ITEM_(\w+)')
-trainer_double_battle_definition   = re.compile(r'\.doubleBattle = (\w+)')
 trainer_ai_flags_definition        = re.compile(r'\.aiFlags = (.*)')
 trainer_ai_flag_definition         = re.compile(r'AI_FLAG_(\w+)')
 trainer_party_definition           = re.compile(r'\.party = TRAINER_PARTY\((\w+)\)')
@@ -211,7 +210,6 @@ class Trainer:
         self.pic = None
         self.name = None
         self.items = []
-        self.double_battle = None
         self.ai_flags = None
         self.mugshot = None
         self.starting_status = None
@@ -250,14 +248,6 @@ def convert_trainers(in_path, in_h, parties, out_party):
             elif m := trainer_items_definition.search(line):
                 [items] = m.groups()
                 trainer.items = " / ".join(item.replace("_", " ").title() for item in trainer_item_definition.findall(items) if item != "NONE")
-            elif m := trainer_double_battle_definition.search(line):
-                [double_battle] = m.groups()
-                if double_battle == 'TRUE':
-                    trainer.double_battle = "Yes"
-                elif double_battle == 'FALSE':
-                    trainer.double_battle = "No"
-                else:
-                    raise Exception(f"unknown doubleBattle: '{double_battle}'")
             elif m := trainer_ai_flags_definition.search(line):
                 [ai_flags] = m.groups()
                 trainer.ai_flags = " / ".join(ai_flag.replace("_", " ").title() for ai_flag in trainer_ai_flag_definition.findall(ai_flags))
@@ -285,7 +275,6 @@ def convert_trainers(in_path, in_h, parties, out_party):
                 out_party.write(f"Music: {trainer.encounter_music}\n")
                 if trainer.items:
                     out_party.write(f"Items: {trainer.items}\n")
-                out_party.write(f"Double Battle: {trainer.double_battle}\n")
                 if trainer.ai_flags:
                     out_party.write(f"AI: {trainer.ai_flags}\n")
                 if trainer.mugshot:

--- a/src/data/battle_partners.party
+++ b/src/data/battle_partners.party
@@ -1,10 +1,9 @@
 === PARTNER_NONE ===
-Name: 
+Name:
 Class: Pkmn Trainer 1
 Pic: Brendan
 Gender: Male
 Music: Male
-Double Battle: None
 
 === PARTNER_STEVEN ===
 Name: STEVEN
@@ -12,7 +11,6 @@ Class: Rival
 Pic: Steven
 Gender: Male
 Music: Male
-Double Battle: None
 
 Metang
 Brave Nature

--- a/tools/trainerproc/main.c
+++ b/tools/trainerproc/main.c
@@ -1194,7 +1194,7 @@ static bool parse_trainer(struct Parser *p, const struct Parsed *parsed, struct 
         while (match_empty_line(p)) {}
         if (!parse_pokemon_header(p, &nickname, &species, &gender, &item))
         {
-            if (i > 0 || is_literal_string(trainer->id, "TRAINER_NONE"))
+            if (i > 0 || ends_with(trainer->id, "_NONE"))
                 break;
             if (!p->error)
                 set_parse_error(p, p->location, "expected nickname or species");


### PR DESCRIPTION
Hopefully these'll do it :crossed_fingers:

The `Double Battle: None` thing is because for regular trainers we always outputted a value, whereas for partners I think we never want to output a value.

The `PARTNER_NONE` thing was because we required at least one Pokémon for every trainer unless it was specifically `TRAINER_NONE`, so that's been changed to allow no Pokémon for any `_NONE` constant.